### PR TITLE
Detroit Crime Data

### DIFF
--- a/det/scrape_det_crime.py
+++ b/det/scrape_det_crime.py
@@ -1,0 +1,44 @@
+
+
+import arrow
+import pandas as pd
+
+# Const
+BASE_URL = "https://data.detroitmi.gov/resource/i9ph-uyrp.json?$order=crimeid%20asc"
+LIMIT_PER_REQ = 10000  # Note: this can be set to entire dataset but request may timeout on slow connection
+
+
+# Setup
+available = True
+offset = 0
+df = pd.DataFrame( )
+
+# Pull everything available
+while available :
+	print( '\rEntries pulled: {}'.format( len( df.index ) ), end='' )
+	pageUrl = BASE_URL + '$limit=' + str( LIMIT_PER_REQ ) + '&$offset=' + str( offset )
+	dfTemp = pd.read_json( pageUrl )
+	df = df.append( dfTemp, ignore_index=True )
+	available = len( dfTemp.index ) > 0
+	offset += LIMIT_PER_REQ
+print( )
+
+# Dedicated year, month, day fields
+df['year'] = df['incidentdate'].map( lambda x : arrow.get( x ).datetime.year )
+df['month'] = df['incidentdate'].map( lambda x : arrow.get( x ).datetime.month )
+df['day'] = df['incidentdate'].map( lambda x : arrow.get( x ).datetime.day )
+
+# Get counts based on columns of interest
+df['count'] = 0
+df = df.groupby( ['year', 'month', 'day', 'description'] ).agg( {'count' : 'count'} )
+df = df.reset_index( )
+df = df.loc[:, ['year', 'month', 'day', 'description', 'count']]
+
+# Write out to csv by year
+yearMax = df.loc[:, 'year'].max( )
+yearMin = df.loc[:, 'year'].min( )
+for yr in range( yearMin, yearMax + 1 ) :
+	dfAnnual = df[df['year'] == yr]
+	fileName = 'data/det-{}-crime.csv'.format( yr )
+	dfAnnual.to_csv( fileName, index=False )
+	print( 'Wrote {} entries to'.format( len( dfAnnual.index ) ), fileName )

--- a/det/scrape_det_crime.py
+++ b/det/scrape_det_crime.py
@@ -3,42 +3,49 @@
 import arrow
 import pandas as pd
 
+
 # Const
 BASE_URL = "https://data.detroitmi.gov/resource/i9ph-uyrp.json?$order=crimeid%20asc"
-LIMIT_PER_REQ = 10000  # Note: this can be set to entire dataset but request may timeout on slow connection
-
+# Note: this can be set to entire dataset but request may timeout on slow connection 
+LIMIT_PER_REQ=10000
 
 # Setup
 available = True
 offset = 0
-df = pd.DataFrame( )
+df = pd.DataFrame()
 
 # Pull everything available
 while available :
-	print( '\rEntries pulled: {}'.format( len( df.index ) ), end='' )
-	pageUrl = BASE_URL + '$limit=' + str( LIMIT_PER_REQ ) + '&$offset=' + str( offset )
-	dfTemp = pd.read_json( pageUrl )
-	df = df.append( dfTemp, ignore_index=True )
-	available = len( dfTemp.index ) > 0
-	offset += LIMIT_PER_REQ
-print( )
+    print('\rEntries pulled: {} '.format(len( df.index)))
+    pageUrl = BASE_URL + '&$limit=' + str(LIMIT_PER_REQ) + '&$offset=' + str(offset)
+    dfTemp = pd.read_json( pageUrl )
+    df = df.append(dfTemp, ignore_index=True)
+    available = len(dfTemp.index) > 0
+    offset += LIMIT_PER_REQ
+print()
 
 # Dedicated year, month, day fields
-df['year'] = df['incidentdate'].map( lambda x : arrow.get( x ).datetime.year )
-df['month'] = df['incidentdate'].map( lambda x : arrow.get( x ).datetime.month )
-df['day'] = df['incidentdate'].map( lambda x : arrow.get( x ).datetime.day )
+df['year'] = df['incidentdate'].map(lambda x : arrow.get(x).datetime.year)
+df['month'] = df['incidentdate'].map(lambda x : arrow.get(x).datetime.month)
+df['day'] = df['incidentdate'].map(lambda x : arrow.get(x).datetime.day)
 
 # Get counts based on columns of interest
 df['count'] = 0
-df = df.groupby( ['year', 'month', 'day', 'description'] ).agg( {'count' : 'count'} )
-df = df.reset_index( )
-df = df.loc[:, ['year', 'month', 'day', 'description', 'count']]
+df = df.groupby(['year', 'month', 'day', 'category']).agg({'count' : 'count'})
+df = df.reset_index()
+df = df.loc[:, ['year', 'month', 'day', 'category', 'count']]
+  
 
 # Write out to csv by year
-yearMax = df.loc[:, 'year'].max( )
-yearMin = df.loc[:, 'year'].min( )
-for yr in range( yearMin, yearMax + 1 ) :
-	dfAnnual = df[df['year'] == yr]
-	fileName = 'data/det-{}-crime.csv'.format( yr )
-	dfAnnual.to_csv( fileName, index=False )
-	print( 'Wrote {} entries to'.format( len( dfAnnual.index ) ), fileName )
+yearMax = df.loc[:, 'year'].max()
+yearMin = df.loc[:, 'year'].min()
+for yr in range(yearMin, yearMax + 1) :
+    dfAnnual = df[df['year'] == yr]
+    fileName = 'data/det-{}-crime.csv'.format(yr)
+    dfAnnual.to_csv( fileName, index=False)
+    print( 'Wrote {} entries to'.format(len(dfAnnual.index )), fileName)
+
+    
+    
+    
+    

--- a/det/scrape_det_crime.py
+++ b/det/scrape_det_crime.py
@@ -1,4 +1,5 @@
-
+# default scraper for Detroit crime
+# (Adapted from existing scrapers by msilb7 and wwymak)
 
 import arrow
 import pandas as pd

--- a/det/scrape_det_crime_CL.py
+++ b/det/scrape_det_crime_CL.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Tue Mar 21 22:12:21 2017
+
+@author: johnzupan
+"""
+
+
+
+import arrow
+import pandas as pd
+import argparse
+
+
+def extract_crime_data(LIMIT_PER_REQ=10000):
+    # Note: this can be set to entire dataset but request may timeout on slow connection    
+    
+    # Const
+    BASE_URL = "https://data.detroitmi.gov/resource/i9ph-uyrp.json?$order=crimeid%20asc"
+     
+    
+    
+    # Setup
+    available = True
+    offset = 0
+    df = pd.DataFrame()
+    
+    # Pull everything available
+    while available :
+        print('\rEntries pulled: {} '.format(len( df.index)))
+        if year:
+            pageUrl = BASE_URL + '&$limit=' + str(LIMIT_PER_REQ) + '&$offset=' + str(offset)
+        else:    
+            pageUrl = BASE_URL + '&$limit=' + str(LIMIT_PER_REQ) + '&$offset=' + str(offset)
+        dfTemp = pd.read_json( pageUrl )
+        df = df.append(dfTemp, ignore_index=True)
+        available = len(dfTemp.index) > 0
+        offset += LIMIT_PER_REQ
+    print()
+    
+    # Dedicated year, month, day fields
+    df['year'] = df['incidentdate'].map(lambda x : arrow.get(x).datetime.year)
+    df['month'] = df['incidentdate'].map(lambda x : arrow.get(x).datetime.month)
+    df['day'] = df['incidentdate'].map(lambda x : arrow.get(x).datetime.day)
+    
+    # Get counts based on columns of interest
+    df['count'] = 0
+    df = df.groupby(['year', 'month', 'day', 'category']).agg({'count' : 'count'})
+    df = df.reset_index()
+    df = df.loc[:, ['year', 'month', 'day', 'category', 'count']]
+  
+    
+    # Write out to csv by year
+    yearMax = df.loc[:, 'year'].max()
+    yearMin = df.loc[:, 'year'].min()
+    for yr in range(yearMin, yearMax + 1) :
+        dfAnnual = df[df['year'] == yr]
+        fileName = 'data/det-{}-crime.csv'.format(yr)
+        dfAnnual.to_csv( fileName, index=False)
+        print( 'Wrote {} entries to'.format(len(dfAnnual.index )), fileName)
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('limit', help='how many records would you like to extract \
+                        at a time?', type=int)
+    
+    args = parser.parse_args()
+    result = extract_crime_data(LIMIT_PER_REQ=args.limit)
+    print result
+    
+if __name__ == '__main__':
+    main()
+    
+    
+    
+    

--- a/det/scrape_det_crime_CL.py
+++ b/det/scrape_det_crime_CL.py
@@ -1,11 +1,6 @@
-# -*- coding: utf-8 -*-
-"""
-Created on Tue Mar 21 22:12:21 2017
-
-@author: johnzupan
-"""
-
-
+# scraper for Detroit crime with command line arguments
+# to specify a year, neighborhood, or zip code 
+# (Adapted from existing scrapers by msilb7 and wwymak)
 
 import arrow
 import pandas as pd
@@ -13,13 +8,11 @@ import argparse
 
 
 def extract_crime_data(LIMIT_PER_REQ=10000, year=None, zipcode=None):
-    # Note: this can be set to entire dataset but request may timeout on slow connection    
+    # Note: LIMIT_PER_REQ can be set to entire dataset but request may timeout on slow connection    
     
     # Const
     BASE_URL = "https://data.detroitmi.gov/resource/i9ph-uyrp.json?"
      
-    
-    
     # Setup
     available = True
     offset = 0
@@ -31,27 +24,31 @@ def extract_crime_data(LIMIT_PER_REQ=10000, year=None, zipcode=None):
         
         if zipcode and year:
             start_year= str(year)
-            end_year = str(year + 1)
             zipcode = str(zipcode)
             pageUrl = BASE_URL + 'location_zip=' + zipcode +'&$where=incidentdate%20between%20%27'+ \
-            start_year+'-01-01T00:00:00.000%27%20and%20%27' + \
-            end_year + '-01-01T00:00:00.000%27'+ \
-            '&$order=crimeid%20asc' + '&$limit=' + str(LIMIT_PER_REQ) + '&$offset=' + str(offset)
+                        start_year+'-01-01T00:00:00.000%27%20and%20%27' + \
+                        start_year + '-12-31T01:00:00.000%27'+ \
+                        '&$order=crimeid%20asc' + '&$limit=' + str(LIMIT_PER_REQ) + '&$offset=' + str(offset)
         elif year:
             start_year= str(year)
-            end_year = str(year + 1)
             pageUrl = BASE_URL +'$where=incidentdate%20between%20%27'+start_year+'-01-01T00:00:00.000%27%20and%20%27' + \
-            end_year + '-01-01T00:00:00.000%27'+ \
-            '&$order=crimeid%20asc' + '&$limit=' + str(LIMIT_PER_REQ) + '&$offset=' + str(offset)
+                        start_year + '-12-31T01:00:00.000%27'+ \
+                        '&$order=crimeid%20asc' + '&$limit=' + str(LIMIT_PER_REQ) + '&$offset=' + str(offset)
+
+        elif zipcode:
+            zipcode = str(zipcode)
+            pageUrl = BASE_URL + 'location_zip='+ zipcode + \
+                      '&$order=crimeid%20asc' + '&$limit=' + str(LIMIT_PER_REQ) + '&$offset=' + str(offset)
               
-        else:    
+             
+        else:
             pageUrl = BASE_URL + '&$order=crimeid%20asc' + '&$limit=' + str(LIMIT_PER_REQ) + '&$offset=' + str(offset)
-            
+
         dfTemp = pd.read_json( pageUrl )
         df = df.append(dfTemp, ignore_index=True)
         available = len(dfTemp.index) > 0
         offset += LIMIT_PER_REQ
-    print()
+    print
     
     # Dedicated year, month, day fields
     df['year'] = df['incidentdate'].map(lambda x : arrow.get(x).datetime.year)
@@ -68,23 +65,24 @@ def extract_crime_data(LIMIT_PER_REQ=10000, year=None, zipcode=None):
     # Write out to csv by year
     yearMax = df.loc[:, 'year'].max()
     yearMin = df.loc[:, 'year'].min()
+    
     for yr in range(yearMin, yearMax + 1) :
         dfAnnual = df[df['year'] == yr]
         fileName = 'data/det-{}-crime.csv'.format(yr)
-        dfAnnual.to_csv( fileName, index=False)
+        dfAnnual.to_csv(fileName, index=False)
         print( 'Wrote {} entries to'.format(len(dfAnnual.index )), fileName)
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('limit', nargs='?', default=10, help='records pulled per request', type=int)
+    parser.add_argument('-l','--limit', nargs='?', default=10, help='records pulled per request', type=int)
                         
-    parser.add_argument('year', nargs='?', default=None, help='year data to be pulled', type=int)
+    parser.add_argument('-y','--year', nargs='?', default=None, help='year data to be pulled', type=int)
     
-    parser.add_argument('zip', nargs='?', default=None, help='zipcode data to be pulled', type=int)    
+    parser.add_argument('-z','--zip', nargs='?', default=None, help='zipcode data to be pulled', type=int)    
     
     args = parser.parse_args()
-    result = extract_crime_data(LIMIT_PER_REQ=args.limit, year=args.year, zipcode=args.zip)
-    print result
+    
+    extract_crime_data(LIMIT_PER_REQ=args.limit, year=args.year, zipcode=args.zip)
     
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Python scraper used to pull Detroit crime data via the Socrata API.  Two pieces of code, the first pulls all crime in Detroit since 2009 and puts each year into its own csv file.  The second allows for optional command line arguments where you can specify a limit, zip code, and/or year.

The data folder is currently empty.  I can add the Detroit Crime csv files if we want them in the repo as well.